### PR TITLE
Switch to ruby2.6 for EL7

### DIFF
--- a/data/os/RedHat/7.yaml
+++ b/data/os/RedHat/7.yaml
@@ -1,5 +1,5 @@
 ---
 oxidized::ruby_dependencies:
-  - rh-ruby23
-  - rh-ruby23-ruby-devel
-oxidized::service_start: '/bin/bash -c "/bin/scl enable rh-ruby23 -- oxidized"'
+  - rh-ruby26
+  - rh-ruby26-ruby-devel
+oxidized::service_start: '/bin/bash -c "/bin/scl enable rh-ruby26 -- oxidized"'

--- a/files/scl_gem
+++ b/files/scl_gem
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-source scl_source enable rh-ruby23
+source scl_source enable rh-ruby26
 gem "$@"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -89,7 +89,7 @@ class oxidized (
     if versioncmp($facts['os']['release']['major'], '8') >= 0 {
       $bootstrap_command = 'oxidized'
     } else {
-      $bootstrap_command = 'scl enable rh-ruby23 -- oxidized'
+      $bootstrap_command = 'scl enable rh-ruby26 -- oxidized'
     }
   } else {
     $bootstrap_command = 'oxidized'


### PR DESCRIPTION
Recent versions of the ed25519 gem require ruby 2.4+.

EL7 SCL has a ruby26 collection, so by switching to that we can install successfully.
